### PR TITLE
feat: Add scrollBehavior prop to customize scroll behavior on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@
   &nbsp;
   &nbsp;
   &nbsp;
-  &nbsp;
   After
   <p align="center">
     <img src="https://github.com/almond-bongbong/react-bottom-fixed/raw/main/example/before.gif" width="300px" />
@@ -104,10 +103,16 @@ function MyApp() {
 
 ### `BottomFixed` Props
 
-| Property    | Type        | Required | Description                     |
-| ----------- | ----------- | -------- | ------------------------------- |
-| `children`  | `ReactNode` | ✅       | Component to be fixed at bottom |
-| `className` | `string`    | ❌       | Additional CSS class name       |
+| Property         | Type                             | Required | Description                                               |
+| ---------------- | -------------------------------- | -------- | --------------------------------------------------------- |
+| `children`       | `ReactNode`                      | ✅       | Component to be fixed at bottom                           |
+| `className`      | `string`                         | ❌       | Additional CSS class name                                 |
+| `scrollBehavior` | `'fade-out' \| 'close-keyboard'` | ❌       | Controls behavior when user scrolls during keyboard input |
+
+### `scrollBehavior` Options
+
+- **`'fade-out'`** (default): Button fades out when user scrolls to avoid blocking content
+- **`'close-keyboard'`**: Automatically closes the keyboard when user starts scrolling
 
 ## Browser Support 🌐
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,7 +21,7 @@
       }
     },
     "..": {
-      "version": "0.0.3-rc.8",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/example/src/_app.tsx
+++ b/example/src/_app.tsx
@@ -1,4 +1,8 @@
-import { BottomFixed } from 'react-bottom-fixed';
+import {
+  BottomFixed,
+  ScrollBehavior,
+  ScrollBehaviorType,
+} from 'react-bottom-fixed';
 import './styles/reset.css';
 import styles from './styles/index.module.scss';
 import { useState } from 'react';
@@ -10,14 +14,13 @@ function App() {
     localStorage.getItem(LONG_CONTENT_KEY) === 'true',
   );
 
+  const [scrollBehavior, setScrollBehavior] = useState<ScrollBehaviorType>(
+    ScrollBehavior.FADE_OUT,
+  );
+
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Smart Mobile CTA Button</h1>
-      <p className={styles.description}>
-        Transform your mobile user experience with our open-source CTA button
-        library. Perfect for e-commerce, lead generation, and conversion
-        optimization.
-      </p>
 
       <button
         type="button"
@@ -35,6 +38,40 @@ function App() {
         className={styles.input}
         placeholder="Search documentation..."
       />
+
+      <div className={styles.scroll_behavior_container}>
+        <h3 className={styles.subtitle}>Scroll Behavior Settings</h3>
+        <div className={styles.radio_group}>
+          <label
+            className={`${styles.radio_label} ${scrollBehavior === ScrollBehavior.FADE_OUT ? styles.selected : ''}`}
+          >
+            <input
+              type="radio"
+              name="scrollBehavior"
+              value="fade-out"
+              checked={scrollBehavior === ScrollBehavior.FADE_OUT}
+              onChange={(e) =>
+                setScrollBehavior(e.target.value as ScrollBehaviorType)
+              }
+            />
+            <span>fade-out</span>
+          </label>
+          <label
+            className={`${styles.radio_label} ${scrollBehavior === ScrollBehavior.CLOSE_KEYBOARD ? styles.selected : ''}`}
+          >
+            <input
+              type="radio"
+              name="scrollBehavior"
+              value="close-keyboard"
+              checked={scrollBehavior === ScrollBehavior.CLOSE_KEYBOARD}
+              onChange={(e) =>
+                setScrollBehavior(e.target.value as ScrollBehaviorType)
+              }
+            />
+            <span>close-keyboard</span>
+          </label>
+        </div>
+      </div>
 
       {isLongContent && (
         <div className={styles.long_content}>
@@ -69,7 +106,7 @@ function App() {
         </div>
       )}
 
-      <BottomFixed className={styles.cta} scrollBehavior="close-keyboard">
+      <BottomFixed className={styles.cta} scrollBehavior={scrollBehavior}>
         <button
           type="button"
           className={styles.button}

--- a/example/src/_app.tsx
+++ b/example/src/_app.tsx
@@ -69,7 +69,7 @@ function App() {
         </div>
       )}
 
-      <BottomFixed className={styles.cta}>
+      <BottomFixed className={styles.cta} scrollBehavior="close-keyboard">
         <button
           type="button"
           className={styles.button}

--- a/example/src/styles/index.module.scss
+++ b/example/src/styles/index.module.scss
@@ -1,41 +1,34 @@
 .container {
   max-width: 600px;
   margin: 0 auto;
-  padding: 32px 24px 120px;
+  padding: 19px 16px 80px;
   background-color: #ffffff;
   min-height: 100vh;
 }
 
 .title {
-  font-size: 2rem;
+  font-size: 1.12rem;
   font-weight: 800;
   color: #1a1a1a;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
   letter-spacing: -0.5px;
-}
-
-.description {
-  margin-top: 16px;
-  color: #666;
-  line-height: 1.6;
-  font-size: 1.1rem;
 }
 
 .input {
   display: block;
   width: 100%;
-  margin-top: 24px;
-  padding: 16px;
+  margin-top: 14px;
+  padding: 13px;
   border: 2px solid #e0e0e0;
-  border-radius: 12px;
-  font-size: 1rem;
+  border-radius: 10px;
+  font-size: 0.8rem;
   transition: all 0.2s ease;
   background-color: #f8f9fa;
 
   &:focus {
     outline: none;
     border-color: #4f46e5;
-    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+    box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
     background-color: #ffffff;
   }
 }
@@ -43,16 +36,16 @@
 .button {
   display: block;
   width: 100%;
-  padding: 16px 24px;
-  border-radius: 12px;
+  padding: 13px 19px;
+  border-radius: 10px;
   background-color: #4f46e5;
   color: #fff;
   border: none;
   font-weight: 600;
-  font-size: 1.1rem;
+  font-size: 0.88rem;
   cursor: pointer;
   transition: all 0.2s ease;
-  box-shadow: 0 4px 6px rgba(79, 70, 229, 0.1);
+  box-shadow: 0 3px 5px rgba(79, 70, 229, 0.1);
 
   &:hover {
     background-color: #4338ca;
@@ -67,13 +60,13 @@
 
 .link {
   display: inline-block;
-  margin-top: 24px;
+  margin-top: 19px;
   color: #4f46e5;
   text-decoration: none;
   font-weight: 500;
   transition: color 0.2s ease;
-  padding: 8px 16px;
-  border-radius: 8px;
+  padding: 6px 13px;
+  border-radius: 6px;
   background-color: rgba(79, 70, 229, 0.1);
 
   &:hover {
@@ -83,18 +76,63 @@
 }
 
 .long_content {
-  margin-top: 32px;
-  padding: 24px;
+  margin-top: 26px;
+  padding: 19px;
   background-color: #f8f9fa;
-  border-radius: 16px;
+  border-radius: 13px;
   line-height: 1.8;
   color: #4a5568;
 }
 
 .cta {
-  left: 24px;
-  right: 24px;
-  bottom: 24px;
+  left: 19px;
+  right: 19px;
+  bottom: 19px;
   padding: 0;
   background: transparent;
+}
+
+.scroll_behavior_container {
+  margin-top: 26px;
+
+  .subtitle {
+    font-size: 0.96rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    letter-spacing: -0.5px;
+  }
+}
+
+.radio_group {
+  margin-top: 19px;
+  
+  .radio_label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 13px;
+    margin-bottom: 10px;
+    border: 2px solid #e0e0e0;
+    border-radius: 10px;
+    background-color: #f8f9fa;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      border-color: #4f46e5;
+      background-color: rgba(79, 70, 229, 0.05);
+    }
+    
+    &.selected {
+      border-color: #4f46e5;
+      background-color: rgba(79, 70, 229, 0.1);
+      box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.1);
+    }
+  }
+  
+  .radio_input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
     "react-hooks",
     "bottom-navigation",
     "keyboard-aware"
-  ]
+  ],
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -296,12 +296,12 @@ export function BottomFixed({
       if (!isKeyboardVisibleWithDelay) return;
       if (timer) window.clearTimeout(timer);
 
-      if (
-        scrollBehavior === ScrollBehavior.CLOSE_KEYBOARD &&
-        isKeyboardVisible
-      ) {
+      if (scrollBehavior === ScrollBehavior.CLOSE_KEYBOARD) {
         // Close keyboard by removing focus from the active element
-        if (document.activeElement instanceof HTMLElement) {
+        if (
+          isKeyboardVisible &&
+          document.activeElement instanceof HTMLElement
+        ) {
           document.activeElement.blur();
         }
         return;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,12 +63,25 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import './index.css';
 
+export const ScrollBehavior = {
+  FADE_OUT: 'fade-out',
+  CLOSE_KEYBOARD: 'close-keyboard',
+} as const;
+
+export type ScrollBehaviorType =
+  (typeof ScrollBehavior)[keyof typeof ScrollBehavior];
+
 export interface BottomFixedProps {
   children: ReactNode;
   className?: string;
+  scrollBehavior?: ScrollBehaviorType;
 }
 
-export function BottomFixed({ children, className }: BottomFixedProps) {
+export function BottomFixed({
+  children,
+  className,
+  scrollBehavior = ScrollBehavior.FADE_OUT,
+}: BottomFixedProps) {
   // DOM reference to the CTA container that we ultimately translate vertically
   const ctaRef = useRef<HTMLDivElement>(null);
 
@@ -189,7 +202,7 @@ export function BottomFixed({ children, className }: BottomFixedProps) {
     viewportChangeHandler();
 
     // Delay timer — makes sure keyboard animation fully settles before we treat
-    // it as “visible with delay”.
+    // it as "visible with delay".
     let keyboardVisibleDelayTimer: number | null = null;
 
     // ────────────── Focus Handlers ──────────────
@@ -274,6 +287,14 @@ export function BottomFixed({ children, className }: BottomFixedProps) {
       if (!isKeyboardVisibleWithDelay) return;
       if (timer) window.clearTimeout(timer);
 
+      if (scrollBehavior === ScrollBehavior.CLOSE_KEYBOARD) {
+        // Close keyboard by removing focus from the active element
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+        return;
+      }
+
       // Continuous scroll → keep CTA hidden until scrolling pauses
       setIsHide(true);
 
@@ -298,7 +319,7 @@ export function BottomFixed({ children, className }: BottomFixedProps) {
       window.removeEventListener('touchend', handleTouchEnd);
       window.removeEventListener('scroll', handleScroll);
     };
-  }, []);
+  }, [scrollBehavior]);
 
   return (
     <div


### PR DESCRIPTION
## Changes
- Add `scrollBehavior` prop to choose scroll behavior
  - `FADE_OUT`: existing behavior, fade out CTA on scroll (default)
  - `CLOSE_KEYBOARD`: dismiss keyboard on scroll
- Use const assertion instead of enum for better type safety
- Maintain iOS-only behavior

## Usage Example
```tsx
// Default behavior
<BottomFixed>
  <Button>Submit</Button>
</BottomFixed>

// Dismiss keyboard on scroll
<BottomFixed scrollBehavior={ScrollBehavior.CLOSE_KEYBOARD}>
  <Button>Submit</Button>
</BottomFixed>
```

## Why
- Provide option to dismiss keyboard on scroll for better content visibility
- Allow choice between existing fade-out behavior and new keyboard dismissal
- Improve developer experience with enhanced type safety

## Testing
1. Test on iOS devices
2. Verify behavior with different `scrollBehavior` prop values
3. When scrolling with keyboard open:
   - `FADE_OUT`: CTA fades out
   - `CLOSE_KEYBOARD`: keyboard dismisses

## Notes
- No breaking changes (default behavior remains unchanged)
- Maintains iOS-only behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to control the behavior of the bottom-fixed component during scrolling: users can now choose between fading out the call-to-action or automatically closing the on-screen keyboard.
- **Enhancements**
  - Improved touch and scroll handling for the bottom-fixed component to better detect user gestures and respond accordingly, especially on mobile devices.
  - Introduced UI controls to toggle scroll behavior dynamically.
  - Updated documentation with detailed explanations of the new scroll behavior options.
  - Refined styles for a more compact layout and enhanced radio button interactions.
- **Chores**
  - Added package manager specification to the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->